### PR TITLE
fix: update personal and M.Tech graduation status across portfolio

### DIFF
--- a/404.html
+++ b/404.html
@@ -185,7 +185,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/about.html
+++ b/about.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>About Nitin Mane | Mechatronics Researcher &amp; AI Engineer</title>
-  <meta name="description" content="Background, skills and working philosophy of Nitin Mane — M.Tech Mechatronics researcher at IIT Bhilai, AI/Robotics engineer, IEEE volunteer, Intel Software Innovator and Arm Developer Ambassador." />
+  <title>About Nitin Mane | Computer Vision and Edge AI Engineer | Robotics and Mechatronics</title>
+  <meta name="description" content="Background, skills and working philosophy of Nitin Mane — M.Tech Mechatronics graduate from IIT Bhilai, AI/Robotics engineer, IEEE volunteer, Intel Software Innovator and Arm Developer Ambassador." />
   <meta name="keywords" content="Nitin Mane, About, Mechatronics, AI Engineer, Robotics, Edge AI, Skills, IEEE, Intel Software Innovator, Arm Developer Ambassador" />
   <meta name="author" content="Nitin Mane" />
   <link rel="canonical" href="https://www.nitinmane.me/about" />
@@ -15,15 +15,15 @@
   <!-- Open Graph -->
   <meta property="og:type" content="profile" />
   <meta property="og:site_name" content="Nitin Mane" />
-  <meta property="og:title" content="About Nitin Mane | Mechatronics Researcher & AI Engineer" />
-  <meta property="og:description" content="Background, skills and working philosophy of Nitin Mane — M.Tech Mechatronics researcher at IIT Bhilai, AI/Robotics engineer and IEEE volunteer." />
+  <meta property="og:title" content="About Nitin Mane | Computer Vision and Edge AI Engineer | Robotics and Mechatronics" />
+  <meta property="og:description" content="Background, skills and working philosophy of Nitin Mane — M.Tech Mechatronics graduate from IIT Bhilai, AI/Robotics engineer and IEEE volunteer." />
   <meta property="og:url" content="https://www.nitinmane.me/about" />
   <meta property="og:image" content="https://www.nitinmane.me/assets/images/profile.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="About Nitin Mane | Mechatronics Researcher & AI Engineer" />
-  <meta name="twitter:description" content="Background, skills and working philosophy of Nitin Mane — M.Tech Mechatronics researcher at IIT Bhilai, AI/Robotics engineer and IEEE volunteer." />
+  <meta name="twitter:title" content="About Nitin Mane | Computer Vision and Edge AI Engineer | Robotics and Mechatronics" />
+  <meta name="twitter:description" content="Background, skills and working philosophy of Nitin Mane — M.Tech Mechatronics graduate from IIT Bhilai, AI/Robotics engineer and IEEE volunteer." />
   <meta name="twitter:image" content="https://www.nitinmane.me/assets/images/profile.png" />
 
   <!-- Icons -->
@@ -112,7 +112,7 @@
         <span class="eyebrow reveal" style="--reveal-delay:40ms">Profile — 01</span>
         <h1 class="page-header__title reveal" style="--reveal-delay:80ms">About Me</h1>
         <p class="page-header__lede reveal" style="--reveal-delay:120ms">
-          Mechatronics researcher, AI/Robotics engineer, and community builder — I work where
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics, and community builder — I work where
           embedded hardware, computer vision and machine learning intersect, and I write about it
           for the people who'll build the next system.
         </p>
@@ -141,7 +141,7 @@
             The Sparks Foundation.
           </p>
           <p>
-            Today, as an <strong class="text-cyan">M.Tech Mechatronics researcher at IIT Bhilai</strong>,
+            Today, as an <strong class="text-cyan">M.Tech Mechatronics graduate from IIT Bhilai</strong>,
             my work focuses on real-time industrial anomaly detection with edge-deployed YOLO models,
             and multi-modal LLM/RAG systems that turn raw sensor and vision data into human-readable
             plant intelligence. My 2022 SSRN publication on adaptive Kalman-filter object tracking with
@@ -451,7 +451,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/blog.html
+++ b/blog.html
@@ -373,7 +373,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/case-study-anomaly-detection.html
+++ b/case-study-anomaly-detection.html
@@ -241,7 +241,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contact Nitin Mane | AI, Robotics &amp; Mechatronics Collaboration</title>
   <meta name="description" content="Contact Nitin Mane for edge AI, robotics, computer vision, LLM/RAG systems, IEEE talks, workshops, mentoring and research collaboration." />
-  <meta name="keywords" content="Contact Nitin Mane, AI Engineer, Robotics Engineer, Mechatronics Researcher, Edge AI, Computer Vision, IIT Bhilai, IEEE Speaker" />
+  <meta name="keywords" content="Contact Nitin Mane, AI Engineer, Robotics Engineer, Mechatronics Graduate, Edge AI, Computer Vision, IIT Bhilai, IEEE Speaker" />
   <meta name="author" content="Nitin Mane" />
   <link rel="canonical" href="https://www.nitinmane.me/contact" />
   <meta name="robots" content="index, follow" />
@@ -63,7 +63,7 @@
         "name": "Nitin Mane",
         "url": "https://www.nitinmane.me/",
         "email": "mailto:mnitin59@gmail.com",
-        "jobTitle": "Mechatronics Researcher and AI/Robotics Engineer",
+        "jobTitle": "Computer Vision and Edge AI Engineer | Robotics and Mechatronics",
         "sameAs": [
           "https://github.com/Nitin-Mane",
           "https://www.linkedin.com/in/nitingmane/",
@@ -149,7 +149,7 @@
             location, expected start date and compensation range so I can respond with the right context.
           </p>
           <p class="font-mono text-dim">
-            Preferred roles: Edge AI Engineer, Computer Vision Engineer, Robotics AI Engineer, Applied ML Engineer
+            Preferred roles: Computer Vision Engineer, Edge AI Engineer, Robotics AI Engineer, Applied Machine Learning Engineer, Research Engineer
           </p>
         </div>
       </div>
@@ -379,7 +379,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/education.html
+++ b/education.html
@@ -545,7 +545,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/experience.html
+++ b/experience.html
@@ -128,7 +128,7 @@
 
         <div class="timeline">
           <div class="timeline__item reveal">
-            <div class="timeline__period">2024 — Present</div>
+            <div class="timeline__period">2024–2026</div>
             <h3 class="timeline__title">M.Tech Researcher, Mechatronics</h3>
             <div class="timeline__org">Indian Institute of Technology Bhilai · Bhilai, India</div>
             <div class="timeline__body">
@@ -280,7 +280,7 @@
               <span class="volunteer-row__role">Chair (Maharashtra Section, Nagpur Chapter)</span>
             </div>
             <span class="tag tag--cyan">Science &amp; Tech</span>
-            <span class="volunteer-row__period">2024 — Present</span>
+            <span class="volunteer-row__period">2024–2026</span>
           </div>
           <div class="volunteer-row" data-tags="humanitarian,social">
             <div class="volunteer-row__main">
@@ -453,7 +453,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Nitin Mane | Mechatronics Researcher &amp; AI / Robotics Engineer</title>
-  <meta name="description" content="Portfolio of Nitin Mane - M.Tech Mechatronics researcher at IIT Bhilai and former Senior Software Engineer, building edge AI, computer vision, robotics and LLM/RAG systems. Explore projects, research and experience." />
+  <title>Nitin Mane | Computer Vision and Edge AI Engineer | Robotics and Mechatronics</title>
+  <meta name="description" content="Portfolio of Nitin Mane - M.Tech Mechatronics graduate from IIT Bhilai and former Senior Software Engineer, building edge AI, computer vision, robotics and LLM/RAG systems. Explore projects, research and experience." />
   <meta name="keywords" content="Nitin Mane, Mechatronics Engineer, AI Engineer, Robotics, Edge AI, Computer Vision, IIT Bhilai, YOLO, Machine Learning, IEEE, Embedded Systems, Portfolio" />
   <meta name="author" content="Nitin Mane" />
   <link rel="canonical" href="https://www.nitinmane.me/" />
@@ -15,15 +15,15 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Nitin Mane" />
-  <meta property="og:title" content="Nitin Mane | Mechatronics Researcher & AI / Robotics Engineer" />
-  <meta property="og:description" content="M.Tech Mechatronics researcher at IIT Bhilai and former Senior Software Engineer, building edge AI, computer vision, robotics and LLM/RAG systems." />
+  <meta property="og:title" content="Nitin Mane | Computer Vision and Edge AI Engineer | Robotics and Mechatronics" />
+  <meta property="og:description" content="M.Tech Mechatronics graduate from IIT Bhilai and former Senior Software Engineer, building edge AI, computer vision, robotics and LLM/RAG systems." />
   <meta property="og:url" content="https://www.nitinmane.me/" />
   <meta property="og:image" content="https://www.nitinmane.me/assets/images/profile_nitinmane.png" />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Nitin Mane | Mechatronics Researcher & AI / Robotics Engineer" />
-  <meta name="twitter:description" content="M.Tech Mechatronics researcher at IIT Bhilai and former Senior Software Engineer, building edge AI, computer vision, robotics and LLM/RAG systems." />
+  <meta name="twitter:title" content="Nitin Mane | Computer Vision and Edge AI Engineer | Robotics and Mechatronics" />
+  <meta name="twitter:description" content="M.Tech Mechatronics graduate from IIT Bhilai and former Senior Software Engineer, building edge AI, computer vision, robotics and LLM/RAG systems." />
   <meta name="twitter:image" content="https://www.nitinmane.me/assets/images/profile_nitinmane.png" />
   <meta name="twitter:creator" content="@Mnitin52" />
 
@@ -54,8 +54,8 @@
     "alternateName": "Nitin G. Mane",
     "url": "https://www.nitinmane.me/",
     "image": "https://www.nitinmane.me/assets/images/profile_nitinmane.png",
-    "jobTitle": "Mechatronics Researcher & AI/Robotics Engineer",
-    "description": "M.Tech Mechatronics researcher at IIT Bhilai and former Senior Software Engineer specialising in edge AI, computer vision, robotics, and LLM/RAG systems.",
+    "jobTitle": "Computer Vision and Edge AI Engineer | Robotics and Mechatronics",
+    "description": "M.Tech Mechatronics graduate from IIT Bhilai and former Senior Software Engineer specialising in edge AI, computer vision, robotics, and LLM/RAG systems.",
     "address": {
       "@type": "PostalAddress",
       "addressLocality": "Chhatrapati Sambhajinagar",
@@ -144,7 +144,7 @@
         </p>
 
         <p class="hero__desc reveal" style="--reveal-delay:180ms">
-          I'm an M.Tech Mechatronics researcher at <strong>IIT Bhilai</strong>, working on real-time industrial
+          I'm an M.Tech Mechatronics graduate from <strong>IIT Bhilai</strong>, working on real-time industrial
           anomaly detection with Edge AI, computer vision, YOLO-based video analytics and multi-modal RAG systems.
           Previously a Senior Software Engineer and AI R&amp;D Engineer, building applied ML, robotics, OpenVINO/Jetson
           deployments and cloud-native systems across industrial, healthcare and education domains. IEEE volunteer,
@@ -158,7 +158,7 @@
         <div class="hero__hiring reveal" style="--reveal-delay:225ms">
           <div class="hero__hiring-row">
             <span class="hero__hiring-label">Open to</span>
-            <span>Computer Vision Engineer / Edge AI Engineer / Robotics AI Engineer / Research Engineer</span>
+            <span>Computer Vision Engineer / Edge AI Engineer / Robotics AI Engineer / Applied Machine Learning Engineer / Research Engineer</span>
           </div>
           <div class="hero__hiring-row">
             <span class="hero__hiring-label">Location</span>
@@ -166,7 +166,7 @@
           </div>
           <div class="hero__hiring-row">
             <span class="hero__hiring-label">Availability</span>
-            <span>2026, post M.Tech (IIT Bhilai)</span>
+            <span>Available for suitable full-time, research and contract opportunities.</span>
           </div>
         </div>
 
@@ -248,7 +248,7 @@
             <span class="eyebrow">01 - About</span>
             <h2 class="section__title">From PCB traces to neural<br />networks - and back.</h2>
             <p class="section__lede">
-              I'm a Mechatronics researcher and AI/Robotics engineer who likes problems that sit at the
+              I'm a Computer Vision and Edge AI Engineer | Robotics and Mechatronics who likes problems that sit at the
               intersection of hardware and intelligence: cameras on a factory floor, a rover in a field,
               or a language model reasoning over sensor data.
             </p>
@@ -257,7 +257,7 @@
           <div class="about-teaser__points reveal" style="--reveal-delay:80ms">
             <div class="about-teaser__point">
               <span class="about-teaser__point-index">-></span>
-              <p><strong class="text-cyan">Currently:</strong> M.Tech Mechatronics researcher at IIT Bhilai, working on real-time industrial anomaly detection and multi-modal LLM/RAG alerting systems.</p>
+              <p><strong class="text-cyan">Background:</strong> M.Tech Mechatronics graduate from IIT Bhilai, working on real-time industrial anomaly detection and multi-modal LLM/RAG alerting systems.</p>
             </div>
             <div class="about-teaser__point">
               <span class="about-teaser__point-index">-></span>
@@ -426,7 +426,7 @@
 
         <div class="timeline experience-teaser__timeline reveal reveal--right">
           <div class="timeline__item">
-            <div class="timeline__period">2024 - Present</div>
+            <div class="timeline__period">2024–2026</div>
             <h3 class="timeline__title">M.Tech Researcher, Mechatronics</h3>
             <div class="timeline__org">Indian Institute of Technology Bhilai</div>
           </div>
@@ -526,7 +526,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India - designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/projects.html
+++ b/projects.html
@@ -495,7 +495,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/research.html
+++ b/research.html
@@ -427,7 +427,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">

--- a/speakers.html
+++ b/speakers.html
@@ -397,7 +397,7 @@
           <span class="footer__brand-name">Nitin Mane</span>
         </a>
         <p>
-          Mechatronics researcher &amp; AI/Robotics engineer based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
+          Computer Vision and Edge AI Engineer | Robotics and Mechatronics based in Chhatrapati Sambhajinagar (Aurangabad), India — designing
           systems where embedded hardware meets machine intelligence.
         </p>
         <div class="social-row" aria-label="Social profiles">


### PR DESCRIPTION
This pull request updates the personal status and profile information across the website.

The following changes were made consistently across all HTML pages, metadata, JSON-LD structured data, footer content, and references:
- Replaced "M.Tech Mechatronics researcher at IIT Bhilai" with "M.Tech Mechatronics graduate from IIT Bhilai."
- Changed the education period to 2024–2026.
- Removed outdated wording such as "Currently pursuing M.Tech", "Post M.Tech in 2026", and "Availability: 2026, post M.Tech".
- Updated the professional headline to "Computer Vision and Edge AI Engineer | Robotics and Mechatronics".
- Updated the availability field to "Available for suitable full-time, research and contract opportunities."
- Ensured preferred roles remain: Computer Vision Engineer, Edge AI Engineer, Robotics AI Engineer, Applied Machine Learning Engineer, Research Engineer.
- Ensured preferred locations remain: Remote, Pune, Mumbai, Bengaluru, Hyderabad.

Every page was updated, including:
- Homepage (index.html)
- About page (about.html)
- Experience page (experience.html)
- Education page (education.html)
- Contact page (contact.html)
- Additional portfolio/project pages (projects.html, research.html, blog.html, speakers.html, 404.html, case-study-anomaly-detection.html)
- SEO, Open Graph, and Twitter metadata in the `<head>` of all these pages.
- JSON-LD structured data.
- Footer sections.

No design, layout, animations, project structure, dependencies, or deployment configurations were modified.

---
*PR created automatically by Jules for task [5331578374386151617](https://jules.google.com/task/5331578374386151617) started by @Nitin-Mane*