### PR TITLE
🧪 Add tests for theme-init.js

### DIFF
--- a/tests/theme-init.test.js
+++ b/tests/theme-init.test.js
@@ -1,0 +1,37 @@
+describe('theme-init.js', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.documentElement.removeAttribute('data-theme');
+    window.localStorage.clear();
+  });
+
+  it('sets theme to light if "light" is in localStorage', () => {
+    window.localStorage.setItem('nitinmane-theme', 'light');
+    require('../assets/js/theme-init.js');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('sets theme to dark if "dark" is in localStorage', () => {
+    window.localStorage.setItem('nitinmane-theme', 'dark');
+    require('../assets/js/theme-init.js');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('does not set theme if invalid theme is in localStorage', () => {
+    window.localStorage.setItem('nitinmane-theme', 'blue');
+    require('../assets/js/theme-init.js');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('sets theme to dark if localStorage throws an error', () => {
+    const spy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('Access denied');
+    });
+
+    require('../assets/js/theme-init.js');
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a test suite for `theme-init.js` to verify that themes are properly applied from `localStorage` and that the application gracefully falls back to the dark theme when `localStorage` throws an exception (e.g. access denied).

📊 **Coverage:** What scenarios are now tested
- Setting the theme to light when "light" is in `localStorage`.
- Setting the theme to dark when "dark" is in `localStorage`.
- Not setting the theme when an invalid string is in `localStorage`.
- Handling errors thrown by `localStorage.getItem` by gracefully falling back to the dark theme.

✨ **Result:** The improvement in test coverage
The previously untested script `theme-init.js` now has a dedicated test file `tests/theme-init.test.js` which provides confidence in theme loading and error handling mechanism, improving overall reliability of the application.

---
*PR created automatically by Jules for task [9287910490550060859](https://jules.google.com/task/9287910490550060859) started by @Nitin-Mane*