### PR TITLE
🔒 Fix insecure HTTP URL in research.html citation

### DIFF
--- a/research.html
+++ b/research.html
@@ -278,7 +278,7 @@
           <div class="publication__citation">
             <div class="publication__citation-head">
               <span class="eyebrow">Cite this work — Vancouver style</span>
-              <button class="btn btn--sm btn--ghost" data-copy="Mishra, Abhilasha and Mane, Nitin and Mishra, Aaditya and Dixit, Amitabh and Mishra, Sparsh and Agrawal, Aditi and Pagare, Rajendraprasad, An Improved Object Tracking and Estimating Using Adaptive Kalman Filter Based Yolov5 Model and Mixed Precision for Efficient Inference Performance. Available at SSRN: https://ssrn.com/abstract=4187576 or http://dx.doi.org/10.2139/ssrn.4187576">
+              <button class="btn btn--sm btn--ghost" data-copy="Mishra, Abhilasha and Mane, Nitin and Mishra, Aaditya and Dixit, Amitabh and Mishra, Sparsh and Agrawal, Aditi and Pagare, Rajendraprasad, An Improved Object Tracking and Estimating Using Adaptive Kalman Filter Based Yolov5 Model and Mixed Precision for Efficient Inference Performance. Available at SSRN: https://ssrn.com/abstract=4187576 or https://dx.doi.org/10.2139/ssrn.4187576">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                 <span data-copy-label>Copy Citation</span>
               </button>
@@ -288,7 +288,7 @@
               Sparsh and Agrawal, Aditi and Pagare, Rajendraprasad, An Improved Object Tracking and
               Estimating Using Adaptive Kalman Filter Based Yolov5 Model and Mixed Precision for
               Efficient Inference Performance. Available at SSRN:
-              https://ssrn.com/abstract=4187576 or http://dx.doi.org/10.2139/ssrn.4187576
+              https://ssrn.com/abstract=4187576 or https://dx.doi.org/10.2139/ssrn.4187576
             </p>
           </div>
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an insecure HTTP URL (`http://dx.doi.org/10.2139/ssrn.4187576`) pointing to an SSRN publication.
⚠️ **Risk:** The potential impact if left unfixed is that user navigation to the URL would occur over an unencrypted connection, putting them at risk for potential interception or man-in-the-middle attacks where the content could be modified or their browsing activity surveilled.
🛡️ **Solution:** The fix replaces the insecure `http://` scheme with `https://` in the `data-copy` attribute and the display text of the citation in `research.html`.

---
*PR created automatically by Jules for task [15122353884642606301](https://jules.google.com/task/15122353884642606301) started by @Nitin-Mane*