### PR TITLE
🔒 Fix insecure innerHTML usage in makeArrow

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -310,7 +310,23 @@
       btn.type = "button";
       btn.className = `gallery__arrow gallery__arrow--${dir}`;
       btn.setAttribute("aria-label", label);
-      btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="${points}"/></svg>`;
+
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("width", "16");
+      svg.setAttribute("height", "16");
+      svg.setAttribute("viewBox", "0 0 24 24");
+      svg.setAttribute("fill", "none");
+      svg.setAttribute("stroke", "currentColor");
+      svg.setAttribute("stroke-width", "2");
+      svg.setAttribute("stroke-linecap", "round");
+      svg.setAttribute("stroke-linejoin", "round");
+
+      const polyline = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
+      polyline.setAttribute("points", points);
+
+      svg.appendChild(polyline);
+      btn.appendChild(svg);
+
       return btn;
     };
     const prevBtn = makeArrow("prev", "Previous photo", "15 18 9 12 15 6");


### PR DESCRIPTION
🎯 **What:** Replaced `innerHTML` with `document.createElementNS` and `setAttribute` for constructing SVG elements.

⚠️ **Risk:** Using `innerHTML` with string interpolation for constructing DOM elements could expose the application to Cross-Site Scripting (XSS) vulnerabilities if the inputs are derived from user-controlled sources. Even though the current inputs are static, it is a bad practice.

🛡️ **Solution:** Migrated the SVG creation logic to use standard, safe DOM manipulation methods (`document.createElementNS` and `setAttribute`), completely eliminating the risk of arbitrary code execution via injection.

---
*PR created automatically by Jules for task [7368441698257013294](https://jules.google.com/task/7368441698257013294) started by @Nitin-Mane*