### PR TITLE
🧪 Add tests for normalizeRoute utility

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -363,4 +363,7 @@
       touchStartX = null;
     });
   });
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = { normalizeRoute };
+  }
 })();

--- a/submission.patch
+++ b/submission.patch
@@ -1,0 +1,92 @@
+diff --git a/assets/js/main.js b/assets/js/main.js
+index 8f258e3..255322f 100644
+--- a/assets/js/main.js
++++ b/assets/js/main.js
+@@ -363,4 +363,7 @@
+       touchStartX = null;
+     });
+   });
++  if (typeof module !== "undefined" && module.exports) {
++    module.exports = { normalizeRoute };
++  }
+ })();
+diff --git a/tests/main.test.js b/tests/main.test.js
+index 70f1e55..08bded0 100644
+--- a/tests/main.test.js
++++ b/tests/main.test.js
+@@ -48,3 +48,75 @@ describe('main.js rotator', () => {
+     expect(rotator.textContent).toBe('');
+   });
+ });
++
++describe('normalizeRoute', () => {
++  let normalizeRoute;
++
++  beforeEach(() => {
++    // Clear module cache to re-evaluate main.js for each test
++    jest.resetModules();
++
++    // We mock matchMedia since it's used globally in main.js
++    Object.defineProperty(window, 'matchMedia', {
++      writable: true,
++      value: jest.fn().mockImplementation(query => ({
++        matches: false,
++        media: query,
++        onchange: null,
++        addListener: jest.fn(),
++        removeListener: jest.fn(),
++        addEventListener: jest.fn(),
++        removeEventListener: jest.fn(),
++        dispatchEvent: jest.fn(),
++      })),
++    });
++
++    const main = require('../assets/js/main.js');
++    normalizeRoute = main.normalizeRoute;
++  });
++
++  it('normalizes the root path to index', () => {
++    expect(normalizeRoute('/')).toBe('index');
++    expect(normalizeRoute('')).toBe('index');
++    expect(normalizeRoute(null)).toBe('index');
++    expect(normalizeRoute(undefined)).toBe('index');
++  });
++
++  it('normalizes basic paths', () => {
++    expect(normalizeRoute('/about')).toBe('about');
++    expect(normalizeRoute('/projects/')).toBe('projects');
++  });
++
++  it('handles deeply nested paths by taking the last segment', () => {
++    expect(normalizeRoute('/blog/2023/10/my-post')).toBe('my-post');
++    expect(normalizeRoute('/blog/2023/10/my-post/')).toBe('my-post');
++  });
++
++  it('strips .html extension', () => {
++    expect(normalizeRoute('/about.html')).toBe('about');
++    expect(normalizeRoute('index.html')).toBe('index');
++    expect(normalizeRoute('/projects/some-project.html')).toBe('some-project');
++  });
++
++  it('strips query parameters', () => {
++    expect(normalizeRoute('/about?ref=twitter')).toBe('about');
++    expect(normalizeRoute('/blog.html?page=2')).toBe('blog');
++  });
++
++  it('strips hash fragments', () => {
++    expect(normalizeRoute('/about#team')).toBe('about');
++    expect(normalizeRoute('/projects.html#details')).toBe('projects');
++  });
++
++  it('handles query parameters and hash fragments together', () => {
++    expect(normalizeRoute('/about.html?ref=twitter#team')).toBe('about');
++    expect(normalizeRoute('/projects?id=123#test')).toBe('projects');
++    expect(normalizeRoute('/#main')).toBe('index');
++    expect(normalizeRoute('/?search=term')).toBe('index');
++  });
++
++  it('is case insensitive regarding .html', () => {
++    expect(normalizeRoute('/about.HTML')).toBe('about');
++    expect(normalizeRoute('/about.HtMl')).toBe('about');
++  });
++});

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -48,3 +48,75 @@ describe('main.js rotator', () => {
     expect(rotator.textContent).toBe('');
   });
 });
+
+describe('normalizeRoute', () => {
+  let normalizeRoute;
+
+  beforeEach(() => {
+    // Clear module cache to re-evaluate main.js for each test
+    jest.resetModules();
+
+    // We mock matchMedia since it's used globally in main.js
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    const main = require('../assets/js/main.js');
+    normalizeRoute = main.normalizeRoute;
+  });
+
+  it('normalizes the root path to index', () => {
+    expect(normalizeRoute('/')).toBe('index');
+    expect(normalizeRoute('')).toBe('index');
+    expect(normalizeRoute(null)).toBe('index');
+    expect(normalizeRoute(undefined)).toBe('index');
+  });
+
+  it('normalizes basic paths', () => {
+    expect(normalizeRoute('/about')).toBe('about');
+    expect(normalizeRoute('/projects/')).toBe('projects');
+  });
+
+  it('handles deeply nested paths by taking the last segment', () => {
+    expect(normalizeRoute('/blog/2023/10/my-post')).toBe('my-post');
+    expect(normalizeRoute('/blog/2023/10/my-post/')).toBe('my-post');
+  });
+
+  it('strips .html extension', () => {
+    expect(normalizeRoute('/about.html')).toBe('about');
+    expect(normalizeRoute('index.html')).toBe('index');
+    expect(normalizeRoute('/projects/some-project.html')).toBe('some-project');
+  });
+
+  it('strips query parameters', () => {
+    expect(normalizeRoute('/about?ref=twitter')).toBe('about');
+    expect(normalizeRoute('/blog.html?page=2')).toBe('blog');
+  });
+
+  it('strips hash fragments', () => {
+    expect(normalizeRoute('/about#team')).toBe('about');
+    expect(normalizeRoute('/projects.html#details')).toBe('projects');
+  });
+
+  it('handles query parameters and hash fragments together', () => {
+    expect(normalizeRoute('/about.html?ref=twitter#team')).toBe('about');
+    expect(normalizeRoute('/projects?id=123#test')).toBe('projects');
+    expect(normalizeRoute('/#main')).toBe('index');
+    expect(normalizeRoute('/?search=term')).toBe('index');
+  });
+
+  it('is case insensitive regarding .html', () => {
+    expect(normalizeRoute('/about.HTML')).toBe('about');
+    expect(normalizeRoute('/about.HtMl')).toBe('about');
+  });
+});


### PR DESCRIPTION
* 🎯 **What:** The testing gap for `normalizeRoute` in `assets/js/main.js` was addressed.
* 📊 **Coverage:** Covered basic paths, hashes, query params, nested paths, and file extensions.
* ✨ **Result:** Ensures the route normalization logic is robust and reliable.

---
*PR created automatically by Jules for task [17982268274627022664](https://jules.google.com/task/17982268274627022664) started by @Nitin-Mane*