### PR TITLE
🧹 Extract makeArrow function to reduce duplication

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -287,6 +287,15 @@
   /* ---------- Sliding photo galleries (speaking / workshop pages) ---------- */
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
+  const makeArrow = (dir, label, points) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = `gallery__arrow gallery__arrow--${dir}`;
+    btn.setAttribute("aria-label", label);
+    btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="${points}"/></svg>`;
+    return btn;
+  };
+
   document.querySelectorAll(".gallery").forEach((gallery) => {
     const track = gallery.querySelector(".gallery__track");
     const slides = Array.from(gallery.querySelectorAll(".gallery__slide"));
@@ -305,14 +314,6 @@
       dots.appendChild(dot);
     });
 
-    const makeArrow = (dir, label, points) => {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = `gallery__arrow gallery__arrow--${dir}`;
-      btn.setAttribute("aria-label", label);
-      btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="${points}"/></svg>`;
-      return btn;
-    };
     const prevBtn = makeArrow("prev", "Previous photo", "15 18 9 12 15 6");
     const nextBtn = makeArrow("next", "Next photo", "9 18 15 12 9 6");
 


### PR DESCRIPTION
🎯 What: Extracted the makeArrow function out of the .gallery forEach loop.
💡 Why: Improves maintainability and reduces memory footprint by reusing the same function instance across all galleries instead of creating a new one on every loop iteration.
✅ Verification: Tested with 'npm test' and 'node -c assets/js/main.js' which pass successfully. Verified visually via Playwright screenshot.
✨ Result: Cleaner code structure and more efficient execution without changing user-facing behavior.

---
*PR created automatically by Jules for task [3347646311470063221](https://jules.google.com/task/3347646311470063221) started by @Nitin-Mane*