### PR TITLE
Fix CI/CD status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # 🌐 Personal Website
 
-[![Website Deploy](https://github.com/Nitin-Mane/Nitin-Mane.github.io/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/USERNAME/REPOSITORY/actions/workflows/deploy.yml)
+[![Website Deploy](https://github.com/Nitin-Mane/Nitin-Mane.github.io/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/Nitin-Mane/Nitin-Mane.github.io/actions/workflows/deploy.yml)
 ![HTML](https://img.shields.io/badge/HTML5-Static_Webpages-orange?style=for-the-badge&logo=html5)
 ![CSS](https://img.shields.io/badge/CSS3-Custom_Theme-blue?style=for-the-badge&logo=css3)
 ![Hosting](https://img.shields.io/badge/Hosted_on-Namecheap-purple?style=for-the-badge)
@@ -303,7 +303,7 @@ This repository uses GitHub Actions to track the project status.
 Workflow badge used in this README:
 
 ```markdown
-[![Website Deploy](https://github.com/USERNAME/REPOSITORY/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/USERNAME/REPOSITORY/actions/workflows/deploy.yml)
+[![Website Deploy](https://github.com/Nitin-Mane/Nitin-Mane.github.io/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/Nitin-Mane/Nitin-Mane.github.io/actions/workflows/deploy.yml)
 ```
 
 Make sure this file exists:


### PR DESCRIPTION
This PR updates the placeholder `USERNAME/REPOSITORY` in the `README.md` to point to the correct GitHub repository (`Nitin-Mane/Nitin-Mane.github.io`). This fixes the CI/CD status badge for the project deployment.

---
*PR created automatically by Jules for task [2795144346597730830](https://jules.google.com/task/2795144346597730830) started by @Nitin-Mane*