### PR TITLE
🧹 [code health improvement] Refactor long SVG template literal string to multiline in assets/js/main.js

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -339,7 +339,20 @@
       btn.type = "button";
       btn.className = `gallery__arrow gallery__arrow--${dir}`;
       btn.setAttribute("aria-label", label);
-      btn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="${points}"/></svg>`;
+      btn.innerHTML = `
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="${points}"/>
+        </svg>
+      `.trim();
       return btn;
     };
 


### PR DESCRIPTION
🎯 **What:** A long single-line template literal used to inject an SVG in `assets/js/main.js` was refactored into a multiline string.
💡 **Why:** Breaking down the long string into a multi-line format significantly improves readability and makes it easier for developers to inspect or modify the SVG structure and attributes in the future.
✅ **Verification:** Validated that the code is syntactically correct using `node -c assets/js/main.js`, and ran the full test suite (`npm test`), all 19 tests passed successfully. Format was checked and preserved with `npx prettier --write assets/js/main.js`.
✨ **Result:** A much cleaner, easily understandable SVG rendering script structure.

---
*PR created automatically by Jules for task [6343109876759284330](https://jules.google.com/task/6343109876759284330) started by @Nitin-Mane*